### PR TITLE
Disable Test Coverage Report via DeepSource 

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -7,6 +7,3 @@ enabled = true
   [analyzers.meta]
   runtime_version = "17"
 
-[[analyzers]]
-name = "test-coverage"
-enabled = true

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -7,3 +7,6 @@ enabled = true
   [analyzers.meta]
   runtime_version = "17"
 
+[[analyzers]]
+name = "test-coverage"
+enabled = true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -68,7 +68,8 @@ jobs:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
         run: |
           curl https://deepsource.com/cli | sh
-          ./bin/deepsource analyze
+          pwd && ls bookshop/target/site/jacoco/jacoco.xml
+          ./bin/deepsource report --analyzer test-coverage --key java --value-file bookshop/target/site/jacoco/jacoco.xml
 
   bookshop-admin:
     runs-on: ubuntu-latest
@@ -109,4 +110,5 @@ jobs:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
         run: |
           curl https://deepsource.com/cli | sh
-          ./bin/deepsource analyze
+          pwd && ls bookshop/target/site/jacoco/jacoco.xml
+          ./bin/deepsource report --analyzer test-coverage --key java --value-file bookshop/target/site/jacoco/jacoco.xml

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}  # Uses PR HEAD commit instead of merge
 
       - name: Set Up JDK 17
         uses: actions/setup-java@v4
@@ -78,6 +80,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}  # Uses PR HEAD commit instead of merge
 
       - name: Set Up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -68,7 +68,7 @@ jobs:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
         run: |
           curl https://deepsource.com/cli | sh
-          ./bin/deepsource report --analyzer java
+          ./bin/deepsource analyze
 
   bookshop-admin:
     runs-on: ubuntu-latest
@@ -109,4 +109,4 @@ jobs:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
         run: |
           curl https://deepsource.com/cli | sh
-          ./bin/deepsource report --analyzer java
+          ./bin/deepsource analyze

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -110,5 +110,5 @@ jobs:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
         run: |
           curl https://deepsource.com/cli | sh
-          pwd && ls bookshop/target/site/jacoco/jacoco.xml
-          ./bin/deepsource report --analyzer test-coverage --key java --value-file bookshop/target/site/jacoco/jacoco.xml
+          pwd && ls bookshop-admin/target/site/jacoco/jacoco.xml
+          ./bin/deepsource report --analyzer test-coverage --key java --value-file bookshop-admin/target/site/jacoco/jacoco.xml

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -68,7 +68,7 @@ jobs:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
         run: |
           curl https://deepsource.com/cli | sh
-          ./bin/deepsource report --analyzer test-coverage --key java --value-file bookshop/target/site/jacoco/jacoco.xml
+          ./bin/deepsource report --analyzer java
 
   bookshop-admin:
     runs-on: ubuntu-latest
@@ -109,4 +109,4 @@ jobs:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
         run: |
           curl https://deepsource.com/cli | sh
-          ./bin/deepsource report --analyzer test-coverage --key java --value-file bookshop-admin/target/site/jacoco/jacoco.xml
+          ./bin/deepsource report --analyzer java


### PR DESCRIPTION
This commit focuses on resolving no-merge commit DeepSource test coverage not triggered issue. 


```
Message   Artifact successfully uploaded for repository Spring-Dubbo-Distributed-REST-Service on commit 6714a83deb6502273aefee1e1506e20a16e277f0.
Warning: Looks like the checkout step is making a merge commit. Test coverage Analyzer would not run for the reported artifact because the merge commit doesn't exist upstream.
Please refer to the docs for required changes. Ref: https://docs.deepsource.com/docs/analyzers-test-coverage#with-github-actions
```